### PR TITLE
Changed titles for notify hints. Downgraded ES syntax

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,8 +79,8 @@
       }))
       .pipe(jshint.reporter())
       .pipe(jshint.reporter('fail'))
-      .on('error', notify.onError((error) => {
-        return 'Ooops: ' + error.message;
+      .on('error', notify.onError({
+        title: 'JS'
       }));
   });
 
@@ -92,8 +92,8 @@
       .pipe(htmlhint())
       .pipe(htmlhint.reporter('htmlhint-stylish'))
       .pipe(htmlhint.failReporter({ suppress: true }))
-      .on('error', notify.onError((error) => {
-        return 'Ooops: ' + error.message;
+      .on('error', notify.onError({
+        title: 'HTML'
       }));
   });
 


### PR DESCRIPTION
Changed titles for JS and HTML hints. Downgraded ES6 syntax to ES5 in the hint tasks