### PR TITLE
Delete a redundant 'self' variable

### DIFF
--- a/tasks/build-sass-production.js
+++ b/tasks/build-sass-production.js
@@ -15,8 +15,7 @@ module.exports = function(options) {
   return function() {
     return gulp.src(`./${options.src}/scss/${options.mainScss}`)
       .pipe(sass().on('error', function(err) {
-        let self = this;
-        options.showError.apply(self, ['Sass compile error', err]);
+        options.showError.apply(this, ['Sass compile error', err]);
       }))
       .pipe(rename(options.mainScssMin))
       .pipe(gcmq())

--- a/tasks/build-sass.js
+++ b/tasks/build-sass.js
@@ -20,8 +20,7 @@ module.exports = function(options) {
         loadMaps: true
       }))
       .pipe(sass().on('error', function(err) {
-        let self = this;
-        options.showError.apply(self, ['Sass compile error', err]);
+        options.showError.apply(this, ['Sass compile error', err]);
       }))
       .pipe(autoprefixer(options.versions))
       .pipe(sourcemaps.write('./'))


### PR DESCRIPTION
Delete a redundant 'self' variable in 'build-sass-production' and 'build-sass' tasks